### PR TITLE
feat: Add support for CLAUDE_CONFIG_DIR environment variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a CLI tool that prunes Claude Code session transcript files (`.jsonl`) to reduce context usage. The tool operates on session files stored in `~/.claude/projects/{project-path-with-hyphens}/{sessionId}.jsonl`.
+This is a CLI tool that prunes Claude Code session transcript files (`.jsonl`) to reduce context usage. The tool operates on session files stored in `$CLAUDE_CONFIG_DIR/projects/{project-path-with-hyphens}/{sessionId}.jsonl` (where `$CLAUDE_CONFIG_DIR` defaults to `~/.claude` if not set).
 
 ## Essential Commands
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ For example, a project at `/Users/alice/my-app` becomes:
 ~/.claude/projects/-Users-alice-my-app/{sessionId}.jsonl
 ```
 
+## Environment Variables
+
+### CLAUDE_CONFIG_DIR
+
+By default, claude-prune looks for session files in `~/.claude`. If Claude Code is configured to use a different directory, you can specify it with the `CLAUDE_CONFIG_DIR` environment variable:
+
+```bash
+# Use a custom Claude config directory
+CLAUDE_CONFIG_DIR=/custom/path/to/claude claude-prune <sessionId> --keep 50
+```
+
 ## Development
 
 ```bash

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,42 @@
-import { describe, it, expect } from 'vitest';
-import { pruneSessionLines, findLatestBackup } from './index.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { pruneSessionLines, findLatestBackup, getClaudeConfigDir } from './index.js';
+import { homedir } from 'os';
+import { join } from 'path';
+
+describe('getClaudeConfigDir', () => {
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    originalEnv = process.env.CLAUDE_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalEnv;
+    }
+  });
+
+  it('should return ~/.claude when CLAUDE_CONFIG_DIR is not set', () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    const result = getClaudeConfigDir();
+    expect(result).toBe(join(homedir(), '.claude'));
+  });
+
+  it('should return CLAUDE_CONFIG_DIR when set', () => {
+    const customPath = '/custom/claude/config';
+    process.env.CLAUDE_CONFIG_DIR = customPath;
+    const result = getClaudeConfigDir();
+    expect(result).toBe(customPath);
+  });
+
+  it('should fallback to ~/.claude when CLAUDE_CONFIG_DIR is an empty string', () => {
+    process.env.CLAUDE_CONFIG_DIR = '';
+    const result = getClaudeConfigDir();
+    expect(result).toBe(join(homedir(), '.claude'));
+  });
+});
 
 describe('pruneSessionLines', () => {
   const createMessage = (type: string, uuid: string, content: string = "test") => 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,11 @@ import chalk from "chalk";
 import ora from "ora";
 import { confirm } from "@clack/prompts";
 
+// ---------- Helper Functions ----------
+export function getClaudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
 // ---------- CLI Definition ----------
 const program = new Command()
   .name("claude-prune")
@@ -136,7 +141,7 @@ if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
 // ---------- Main ----------
 async function main(sessionId: string, opts: { keep: number; dryRun?: boolean }) {
   const cwdProject = process.cwd().replace(/\//g, '-');
-  const file = join(homedir(), ".claude", "projects", cwdProject, `${sessionId}.jsonl`);
+  const file = join(getClaudeConfigDir(), "projects", cwdProject, `${sessionId}.jsonl`);
 
   if (!(await fs.pathExists(file))) {
     console.error(chalk.red(`❌ No transcript at ${file}`));
@@ -162,7 +167,7 @@ async function main(sessionId: string, opts: { keep: number; dryRun?: boolean })
     return;
   }
 
-  const backupDir = join(homedir(), ".claude", "projects", cwdProject, "prune-backup");
+  const backupDir = join(getClaudeConfigDir(), "projects", cwdProject, "prune-backup");
   await fs.ensureDir(backupDir);
   const backup = join(backupDir, `${sessionId}.jsonl.${Date.now()}`);
   await fs.copyFile(file, backup);
@@ -189,8 +194,8 @@ export function findLatestBackup(backupFiles: string[], sessionId: string): { na
 // ---------- Restore ----------
 async function restore(sessionId: string, opts: { dryRun?: boolean }) {
   const cwdProject = process.cwd().replace(/\//g, '-');
-  const file = join(homedir(), ".claude", "projects", cwdProject, `${sessionId}.jsonl`);
-  const backupDir = join(homedir(), ".claude", "projects", cwdProject, "prune-backup");
+  const file = join(getClaudeConfigDir(), "projects", cwdProject, `${sessionId}.jsonl`);
+  const backupDir = join(getClaudeConfigDir(), "projects", cwdProject, "prune-backup");
 
   if (!(await fs.pathExists(backupDir))) {
     console.error(chalk.red(`❌ No backup directory found at ${backupDir}`));


### PR DESCRIPTION
- Support custom Claude config directories via CLAUDE_CONFIG_DIR env var
- Fallback to ~/.claude when environment variable is not set
- Add getClaudeConfigDir() helper function for consistent config path resolution
- Add comprehensive test coverage for the new functionality
- Update documentation to explain the new configuration option

This allows users to use claude-prune with Claude Code installations that have custom config locations set via the CLAUDE_CONFIG_DIR environment variable.

For reference my Claude Code config lives at `~/.config/claude`